### PR TITLE
added http load-balancer

### DIFF
--- a/01-setup/.terraform.lock.hcl
+++ b/01-setup/.terraform.lock.hcl
@@ -3,7 +3,7 @@
 
 provider "registry.terraform.io/hashicorp/google" {
   version     = "4.32.0"
-  constraints = ">= 2.12.0, >= 3.45.0, >= 3.83.0, >= 4.25.0, < 5.0.0"
+  constraints = ">= 2.12.0, >= 3.45.0, >= 3.53.0, >= 3.83.0, >= 4.25.0, < 5.0.0"
   hashes = [
     "h1:hGZiuBPYAQyjp4D8/nLNcNM6T+FYn1YHGM1NdBPGojQ=",
     "zh:03fa16d2811fc3ef523b8afad5ce4c1c72e686a425f48f9432f21b16c55c2872",
@@ -23,7 +23,7 @@ provider "registry.terraform.io/hashicorp/google" {
 
 provider "registry.terraform.io/hashicorp/google-beta" {
   version     = "4.32.0"
-  constraints = ">= 3.45.0, < 5.0.0"
+  constraints = ">= 3.45.0, >= 3.53.0, < 5.0.0"
   hashes = [
     "h1:LmWKQqrwQDiseMYdjq1HnIaEioIXbLJfyTiCYopKMg0=",
     "zh:0226fc19c9ca47bf783ce6052f7e222c48be01711ac98a29bf63fcfa3014d689",
@@ -43,7 +43,7 @@ provider "registry.terraform.io/hashicorp/google-beta" {
 
 provider "registry.terraform.io/hashicorp/kubernetes" {
   version     = "2.12.1"
-  constraints = "~> 2.0, ~> 2.10"
+  constraints = "~> 2.10"
   hashes = [
     "h1:YdDA370JByM9HT5GdLpt34z3BvcVW4BnVXqdgB/vZ6I=",
     "zh:1ecb2adff52754fb4680c7cfe6143d1d8c264b00bb0c44f07f5583b1c7f978b8",
@@ -100,8 +100,7 @@ provider "registry.terraform.io/hashicorp/random" {
 }
 
 provider "registry.terraform.io/integrations/github" {
-  version     = "4.29.0"
-  constraints = "4.29.0"
+  version = "4.29.0"
   hashes = [
     "h1:wUTClojzCWWJENDqCzeeGYcv1VRNVFwkvEsx2vK55KQ=",
     "zh:0eb3ced0c88d3558942bf018e7426f89e8e824c11c01494ce8ea03aa0f1fba9f",

--- a/01-setup/loadbalancer.tf
+++ b/01-setup/loadbalancer.tf
@@ -1,9 +1,12 @@
 module "gce-lb-http" {
   source            = "GoogleCloudPlatform/lb-http/google//modules/dynamic_backends"
   version           = "~> 4.4"
+  for_each = {
+    for index, stage in var.demo_stages : stage.name => stage
+  }
 
   project           = var.project_id
-  name              = "${var.demo_name}-lb"
+  name              = "${var.demo_name}-${each.value.name}-lb"
   target_tags       = [module.mig1.target_tags, module.mig2.target_tags]
   backends = {
     default = {

--- a/01-setup/loadbalancer.tf
+++ b/01-setup/loadbalancer.tf
@@ -1,6 +1,5 @@
 module "gce-lb-http" {
   source            = "GoogleCloudPlatform/lb-http/google//modules/dynamic_backends"
-  version           = "~> 4.4"
   for_each = {
     for index, stage in var.demo_stages : stage.name => stage
   }

--- a/01-setup/loadbalancer.tf
+++ b/01-setup/loadbalancer.tf
@@ -7,7 +7,7 @@ module "gce-lb-http" {
 
   project           = var.project_id
   name              = "${var.demo_name}-${each.value.name}-lb"
-  target_tags       = [module.mig1.target_tags, module.mig2.target_tags]
+  target_tags       = ["gke-node", "${var.project_id}-gke"]
   backends = {
     default = {
       description                     = null

--- a/01-setup/loadbalancer.tf
+++ b/01-setup/loadbalancer.tf
@@ -43,7 +43,7 @@ module "gce-lb-http" {
       groups = [
         {
           # Each node pool instance group should be added to the backend.
-          group                        = "${each.value.name}-node-pool"
+          group                        = "google_container_cluster.${var.demo_name}-${each.value.name}.instance_group_urls[0]"
           balancing_mode               = null
           capacity_scaler              = null
           description                  = null

--- a/01-setup/loadbalancer.tf
+++ b/01-setup/loadbalancer.tf
@@ -39,10 +39,9 @@ module "gce-lb-http" {
         sample_rate = 1.0
       }
 
-      groups = [
-        {
+      groups = [ for group in module.gke[each.key].instance_group_urls : {
           # Each node pool instance group should be added to the backend.
-          group                        =  module.gke[each.key].instance_group_urls[0]
+          group                        =  group
           balancing_mode               = null
           capacity_scaler              = null
           description                  = null
@@ -53,7 +52,7 @@ module "gce-lb-http" {
           max_rate_per_instance        = null
           max_rate_per_endpoint        = null
           max_utilization              = null
-        },
+        }
       ]
 
       iap_config = {

--- a/01-setup/loadbalancer.tf
+++ b/01-setup/loadbalancer.tf
@@ -42,7 +42,7 @@ module "gce-lb-http" {
       groups = [
         {
           # Each node pool instance group should be added to the backend.
-          group                        = "google_container_cluster.${var.demo_name}-${each.value.name}.instance_group_urls[0]"
+          group                        =  module.gke[each.key].instance_group_urls[0]
           balancing_mode               = null
           capacity_scaler              = null
           description                  = null

--- a/01-setup/loadbalancer.tf
+++ b/01-setup/loadbalancer.tf
@@ -43,7 +43,7 @@ module "gce-lb-http" {
       groups = [
         {
           # Each node pool instance group should be added to the backend.
-          group                        = var.backend
+          group                        = "${each.value.name}-node-pool"
           balancing_mode               = null
           capacity_scaler              = null
           description                  = null

--- a/01-setup/loadbalancer.tf
+++ b/01-setup/loadbalancer.tf
@@ -1,0 +1,64 @@
+module "gce-lb-http" {
+  source            = "GoogleCloudPlatform/lb-http/google//modules/dynamic_backends"
+  version           = "~> 4.4"
+
+  project           = var.project_id
+  name              = "${var.demo_name}-lb"
+  target_tags       = [module.mig1.target_tags, module.mig2.target_tags]
+  backends = {
+    default = {
+      description                     = null
+      protocol                        = "HTTP"
+      port                            = var.router_port
+      port_name                       = var.router_port_name
+      timeout_sec                     = 10
+      enable_cdn                      = false
+      custom_request_headers          = null
+      custom_response_headers         = null
+      security_policy                 = null
+
+      connection_draining_timeout_sec = null
+      session_affinity                = null
+      affinity_cookie_ttl_sec         = null
+
+      health_check = {
+        check_interval_sec  = null
+        timeout_sec         = null
+        healthy_threshold   = null
+        unhealthy_threshold = null
+        request_path        = "/"
+        port                = var.router_port
+        host                = null
+        logging             = null
+      }
+
+      log_config = {
+        enable = true
+        sample_rate = 1.0
+      }
+
+      groups = [
+        {
+          # Each node pool instance group should be added to the backend.
+          group                        = var.backend
+          balancing_mode               = null
+          capacity_scaler              = null
+          description                  = null
+          max_connections              = null
+          max_connections_per_instance = null
+          max_connections_per_endpoint = null
+          max_rate                     = null
+          max_rate_per_instance        = null
+          max_rate_per_endpoint        = null
+          max_utilization              = null
+        },
+      ]
+
+      iap_config = {
+        enable               = false
+        oauth2_client_id     = null
+        oauth2_client_secret = null
+      }
+    }
+  }
+}

--- a/01-setup/outputs.tf
+++ b/01-setup/outputs.tf
@@ -4,3 +4,7 @@ output "kubernetes_cluster_names" {
   }
   description = "Cluster names"
 }
+
+output "load-balancer-ip" {
+  value = module.gce-lb-http.external_ip
+}

--- a/01-setup/outputs.tf
+++ b/01-setup/outputs.tf
@@ -22,5 +22,7 @@ output "repo_infra" {
 }
 
 output "load-balancer-ip" {
-  value = module.gce-lb-http.external_ip
+  value = {
+    for k, v in module.gce-lb-http : k => v. external_ip
+  }
 }

--- a/01-setup/router.tf
+++ b/01-setup/router.tf
@@ -4,7 +4,6 @@ resource "google_compute_instance_group_named_port" "router" {
   }
   
   group = module.gke[each.key].instance_group_urls[0]
-  zone = var.project_region
 
   name = var.router_port_name
   port = var.router_port

--- a/01-setup/router.tf
+++ b/01-setup/router.tf
@@ -4,7 +4,7 @@ resource "google_compute_instance_group_named_port" "router" {
   }
   
   group = "google_container_cluster.${var.demo_name}-${each.value.name}.node_pool[0].instance_group_urls[0]"
-  zone = "us-central1-a"
+  zone = var.project_region
 
   name = var.router_port_name
   port = var.router_port

--- a/01-setup/router.tf
+++ b/01-setup/router.tf
@@ -3,7 +3,7 @@ resource "google_compute_instance_group_named_port" "router" {
     for index, stage in var.demo_stages : stage.name => stage
   }
   
-  group = "google_container_cluster.${var.demo_name}-${each.value.name}.node_pool[0].instance_group_urls[0]"
+  group = module.gke[each.key].instance_group_urls[0]
   zone = var.project_region
 
   name = var.router_port_name

--- a/01-setup/router.tf
+++ b/01-setup/router.tf
@@ -1,0 +1,11 @@
+resource "google_compute_instance_group_named_port" "router" {
+  for_each = {
+    for index, stage in var.demo_stages : stage.name => stage
+  }
+  
+  group = "google_container_cluster.${var.demo_name}-${each.value.name}.node_pool[0].instance_group_urls[0]"
+  zone = "us-central1-a"
+
+  name = var.router_port_name
+  port = var.router_port
+}

--- a/01-setup/variables.tf
+++ b/01-setup/variables.tf
@@ -17,11 +17,13 @@ variable "gke_num_nodes" {
 }
 
 variable "router_port" {
-  description = "Apollo Router service port"
+  default = 80
+  description = "Apollo Router service NodePort port number"
 }
 
 variable "router_port_name" {
-  description = "Apollo Router service port name"
+  default = "http"
+  description = "Apollo Router service NodePort port name"
 }
 
 // adding in IP info here to make it easier to manage.

--- a/01-setup/variables.tf
+++ b/01-setup/variables.tf
@@ -16,6 +16,14 @@ variable "gke_num_nodes" {
   description = "number of gke nodes"
 }
 
+variable "router_port" {
+  description = "Apollo Router service port"
+}
+
+variable "router_port_name" {
+  description = "Apollo Router service port name"
+}
+
 // adding in IP info here to make it easier to manage.
 // due to the peering needed to support a shared tooling-infra cluster (for uploading metrics), each subnet cannot conflict; giving each range a healthy /16 avoids potential
 // IP exhaustion for the demo.


### PR DESCRIPTION
This PR is adapted from [these instructions](https://github.com/terraform-google-modules/terraform-google-lb-http/tree/master/examples/https-gke#option-2---example-with-existing-cluster).

- added http load-balancer, ~needs router service from gke and backend pool~
- added named port to the instance group for Apollo Router (http,80)
- outputs external load-balancer-ip